### PR TITLE
Reduce `Binding` variant usages

### DIFF
--- a/crates/core/src/pattern/after.rs
+++ b/crates/core/src/pattern/after.rs
@@ -5,12 +5,11 @@ use super::{
     variable::VariableSourceLocations,
     Node, State,
 };
-use crate::{binding::Binding, context::Context, resolve};
 use crate::{binding::Constant, errors::debug};
+use crate::{context::Context, resolve};
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
 use grit_util::AstNode;
-use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
 
@@ -61,7 +60,7 @@ impl After {
         };
 
         if let Some(next) = node.next_non_trivia_node() {
-            Ok(ResolvedPattern::Binding(vector![Binding::from_node(next)]))
+            Ok(ResolvedPattern::from_node(next))
         } else {
             debug(
                 logs,

--- a/crates/core/src/pattern/ast_node.rs
+++ b/crates/core/src/pattern/ast_node.rs
@@ -7,7 +7,7 @@ use super::{
     variable::VariableSourceLocations,
     State,
 };
-use crate::{binding::Binding, context::Context, resolve};
+use crate::{context::Context, resolve};
 use anyhow::{anyhow, Result};
 use itertools::Itertools;
 use marzano_language::language::{FieldId, Language, SortId};
@@ -163,12 +163,7 @@ impl Matcher for ASTNode {
             return Ok(false);
         };
         if binding.is_list() {
-            return self.execute(
-                &ResolvedPattern::from_binding(Binding::from_node(node)),
-                init_state,
-                context,
-                logs,
-            );
+            return self.execute(&ResolvedPattern::from_node(node), init_state, context, logs);
         }
 
         let NodeWithSource { node, source } = node;
@@ -181,10 +176,9 @@ impl Matcher for ASTNode {
         if context.language().is_comment(self.sort) {
             let content = context.language().comment_text(&node, source);
             let content = resolve!(content);
-            let content = Binding::String(source, content.1);
 
             return self.args[0].2.execute(
-                &ResolvedPattern::from_binding(content),
+                &ResolvedPattern::from_range(content.1, source),
                 init_state,
                 context,
                 logs,

--- a/crates/core/src/pattern/before.rs
+++ b/crates/core/src/pattern/before.rs
@@ -5,12 +5,11 @@ use super::{
     variable::VariableSourceLocations,
     Node, State,
 };
-use crate::{binding::Binding, context::Context, resolve};
 use crate::{binding::Constant, errors::debug};
+use crate::{context::Context, resolve};
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
 use grit_util::AstNode;
-use im::vector;
 use marzano_util::analysis_logs::AnalysisLogs;
 use std::collections::BTreeMap;
 
@@ -61,7 +60,7 @@ impl Before {
         };
 
         if let Some(prev) = node.previous_non_trivia_node() {
-            Ok(ResolvedPattern::Binding(vector![Binding::from_node(prev)]))
+            Ok(ResolvedPattern::from_node(prev))
         } else {
             debug(
                 logs,

--- a/crates/core/src/pattern/list_index.rs
+++ b/crates/core/src/pattern/list_index.rs
@@ -12,8 +12,10 @@ use crate::binding::{Binding, Constant};
 use crate::context::Context;
 use crate::resolve_opt;
 use anyhow::{anyhow, bail, Result};
-use im::vector;
-use marzano_util::{analysis_logs::AnalysisLogs, tree_sitter_util::named_children_by_field_id};
+use marzano_util::{
+    analysis_logs::AnalysisLogs, node_with_source::NodeWithSource,
+    tree_sitter_util::named_children_by_field_id,
+};
 use std::collections::BTreeMap;
 use tree_sitter::Node;
 
@@ -138,9 +140,9 @@ impl ListIndex {
                         let mut list = named_children_by_field_id(node, &mut cursor, *field);
                         let index = resolve_opt!(to_unsigned(index, len));
                         return Ok(list.nth(index).map(|n| {
-                            PatternOrResolved::ResolvedBinding(ResolvedPattern::Binding(vector![
-                                Binding::Node(src, n)
-                            ]))
+                            PatternOrResolved::ResolvedBinding(ResolvedPattern::from_node(
+                                NodeWithSource::new(n, src),
+                            ))
                         }));
                     }
                     bail!("left side of a listIndex must be a list")

--- a/crates/core/src/pattern/or.rs
+++ b/crates/core/src/pattern/or.rs
@@ -74,10 +74,10 @@ impl Matcher for Or {
         if let ResolvedPattern::Binding(binding_vector) = &binding {
             for p in self.patterns.iter() {
                 // filter out pattern which cannot match because of a mismatched node type
-                if let (Binding::Node(_src, binding_node), Pattern::ASTNode(node_pattern)) =
-                    (binding_vector.last().unwrap(), p)
+                if let (Some(binding_node), Pattern::ASTNode(node_pattern)) =
+                    (binding_vector.last().and_then(Binding::as_node), p)
                 {
-                    if node_pattern.sort != binding_node.kind_id() {
+                    if node_pattern.sort != binding_node.node.kind_id() {
                         continue;
                     }
                 }

--- a/crates/core/src/pattern/regex.rs
+++ b/crates/core/src/pattern/regex.rs
@@ -6,10 +6,9 @@ use super::{
     variable::{Variable, VariableSourceLocations},
     State,
 };
-use crate::{binding::Binding, context::Context};
+use crate::context::Context;
 use anyhow::{anyhow, bail, Result};
 use core::fmt::Debug;
-use im::vector;
 use marzano_language::{language::Language, target_language::TargetLanguage};
 use marzano_util::analysis_logs::{AnalysisLogBuilder, AnalysisLogs};
 use marzano_util::position::Range;
@@ -201,7 +200,7 @@ impl RegexPattern {
                             // have a Range<usize> for String bindings?
                             position.end_byte = position.start_byte + range.end as u32;
                             position.start_byte += range.start as u32;
-                            ResolvedPattern::Binding(vector![Binding::String(source, position)])
+                            ResolvedPattern::from_range(position, source)
                         } else {
                             ResolvedPattern::from_string(value.to_string())
                         }

--- a/crates/core/src/pattern/resolved_pattern.rs
+++ b/crates/core/src/pattern/resolved_pattern.rs
@@ -23,6 +23,7 @@ use marzano_util::{
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap},
+    path::Path,
 };
 use tree_sitter::Node;
 
@@ -56,9 +57,7 @@ impl<'a> File<'a> {
     pub(crate) fn name(&self, files: &FileRegistry<'a>) -> ResolvedPattern<'a> {
         match self {
             File::Resolved(resolved) => resolved.name.clone(),
-            File::Ptr(ptr) => {
-                ResolvedPattern::Binding(vector![Binding::FileName(&files.get_file(*ptr).name)])
-            }
+            File::Ptr(ptr) => ResolvedPattern::from_path(&files.get_file(*ptr).name),
         }
     }
 
@@ -69,9 +68,9 @@ impl<'a> File<'a> {
                 let absolute_path = absolutize(name.as_ref())?;
                 Ok(ResolvedPattern::Constant(Constant::String(absolute_path)))
             }
-            File::Ptr(ptr) => Ok(ResolvedPattern::Binding(vector![Binding::FileName(
-                &files.get_file(*ptr).absolute_path
-            )])),
+            File::Ptr(ptr) => Ok(ResolvedPattern::from_path(
+                &files.get_file(*ptr).absolute_path,
+            )),
         }
     }
 
@@ -81,7 +80,7 @@ impl<'a> File<'a> {
             File::Ptr(ptr) => {
                 let file = &files.get_file(*ptr);
                 let range = file.tree.root_node().range().into();
-                ResolvedPattern::Binding(vector![Binding::String(&file.source, range)])
+                ResolvedPattern::from_range(range, &file.source)
             }
         }
     }
@@ -92,7 +91,7 @@ impl<'a> File<'a> {
             File::Ptr(ptr) => {
                 let file = &files.get_file(*ptr);
                 let node = file.tree.root_node();
-                ResolvedPattern::Binding(vector![Binding::Node(&file.source, node)])
+                ResolvedPattern::from_node(NodeWithSource::new(node, &file.source))
             }
         }
     }
@@ -175,7 +174,7 @@ impl<'a> JoinFn<'a> {
                 .children_by_field_id(*field, &mut parent_node.walk())
                 .filter(|child| child.is_named())
                 .map(|p| {
-                    ResolvedPattern::Binding(vector![Binding::Node(src, p)]).linearized_text(
+                    ResolvedPattern::from_node(NodeWithSource::new(p, src)).linearized_text(
                         language,
                         effects,
                         files,
@@ -205,7 +204,7 @@ impl<'a> JoinFn<'a> {
             }) => parent_node
                 .children_by_field_id(*field, &mut parent_node.walk())
                 .filter(|child| child.is_named())
-                .map(|p| ResolvedPattern::Binding(vector![Binding::Node(src, p)]).text(state))
+                .map(|p| ResolvedPattern::from_node(NodeWithSource::new(p, src)).text(state))
                 .collect::<Result<Vec<_>>>()?
                 .join(&self.separator)
                 .into(),
@@ -477,19 +476,27 @@ impl<'a> ResolvedPattern<'a> {
     }
 
     pub fn from_constant(constant: &'a Constant) -> Self {
-        Self::Binding(vector![Binding::ConstantRef(constant)])
+        Self::from_binding(Binding::from_constant(constant))
     }
 
     pub(crate) fn from_node(node: NodeWithSource<'a>) -> Self {
-        Self::Binding(vector![Binding::Node(node.source, node.node)])
+        Self::from_binding(Binding::from_node(node))
     }
 
     pub(crate) fn from_list(src: &'a str, node: Node<'a>, field_id: FieldId) -> Self {
-        Self::Binding(vector![Binding::List(src, node, field_id)])
+        Self::from_binding(Binding::List(src, node, field_id))
     }
 
     pub(crate) fn empty_field(src: &'a str, node: Node<'a>, field_id: FieldId) -> Self {
-        Self::Binding(vector![Binding::Empty(src, node, field_id)])
+        Self::from_binding(Binding::Empty(src, node, field_id))
+    }
+
+    pub(crate) fn from_path(path: &'a Path) -> Self {
+        Self::from_binding(Binding::from_path(path))
+    }
+
+    pub(crate) fn from_range(range: Range, src: &'a str) -> Self {
+        Self::from_binding(Binding::from_range(range, src))
     }
 
     pub fn from_string(string: String) -> Self {

--- a/crates/core/src/text_unparser.rs
+++ b/crates/core/src/text_unparser.rs
@@ -1,4 +1,4 @@
-use crate::binding::{linearize_binding, Binding};
+use crate::binding::linearize_binding;
 use crate::pattern::resolved_pattern::CodeRange;
 use crate::pattern::state::FileRegistry;
 use crate::pattern::Effect;
@@ -46,8 +46,8 @@ pub(crate) fn apply_effects<'a>(
         logs,
     )?;
     for effect in effects.iter() {
-        if let Binding::FileName(c) = effect.binding {
-            if std::ptr::eq(c, the_filename) {
+        if let Some(filename) = effect.binding.as_filename() {
+            if std::ptr::eq(filename, the_filename) {
                 let snippet = effect
                     .pattern
                     .linearized_text(language, &effects, files, &mut memo, false, logs)?;


### PR DESCRIPTION
This PR further reduces the amount of usages of `Binding::*` variants, mostly by using helper functions.

Usages of `Binding::*` variants internal to the struct have been renamed to `Self::*`, so I can quickly filter them out to see which ones remain.

It looks like after this, only some list-related usages remain, which may require slightly more creative solutions :)